### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/taitan/Cargo.toml
+++ b/taitan/Cargo.toml
@@ -3,7 +3,7 @@ name = "taitan"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The Next Generation of Web Framework"
-homepage = "https://github.com/thegenius/taitan"
+repository = "https://github.com/thegenius/taitan"
 version = {workspace = true}
 rust-version = {workspace = true}
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.